### PR TITLE
Performance improvement in makepositive.m

### DIFF
--- a/shared/imageloaders/makepositive.m
+++ b/shared/imageloaders/makepositive.m
@@ -1,7 +1,11 @@
 function out=makepositive(in)
 if isa(in,'int16')
-    out=single(in);
-    out(out<0)=out(out<0)+2^16;
+    % Typecast causes negative int16 values to overflow, adding 2^16
+    % Typecast only works on flat arrays, so first flatten the data
+    positive_values=typecast(in(:), 'uint16');
+
+    % Convert data to single and unflatten
+    out=reshape(single(positive_values), size(in));
 else
     out=in;
 end


### PR DESCRIPTION
To start, thank you for developing this software! It has been incredibly useful in our research.

I have been profiling a performance-critical test workflow and I noticed that [makepositive.m](https://github.com/jries/SMAP/blob/91fc9a0830b8e9c4f3450280e6e2d8a4e8b3ad88/shared/imageloaders/makepositive.m) is a hotspot in our use-case.

`2^16` is added to all negative values of the input array if it has type `int16`, however, this is the same behavior as an intentional overflow caused by typecasting to `uint8`, while being much slower.

For our use-case, makepositive (before changes) takes up around 5% of the overall workflow run time. After changes, it takes up less than 2% of the run time.

Please let me know if you have any feedback or other comments for this change, thanks!