### PR TITLE
Add two new plugins: SiteAutoDetect and AverageSitesByDistance

### DIFF
--- a/plugins/+Analyze/+other/SiteAutoDetect.m
+++ b/plugins/+Analyze/+other/SiteAutoDetect.m
@@ -1,0 +1,414 @@
+classdef SiteAutoDetect<interfaces.DialogProcessor&interfaces.SEProcessor
+% Automatically detects clathrin-coated pit (CCP) sites from SMLM
+% localizations and adds them to the SMAP Site Explorer.
+%
+% Algorithm: density map → Gaussian blur → local maxima → min-distance
+% suppression → centroid refinement → optional locs-count filter → SE.
+    methods
+        function obj=SiteAutoDetect(varargin)
+            obj@interfaces.DialogProcessor(varargin{:});
+            obj.inputParameters={'se_cellfov','se_siteroi'};
+        end
+
+        function out=run(obj,p)
+            params = obj.getParams();
+            if isempty(params), out=[]; return; end
+            obj.doDetect(params, false);
+            out=[];
+        end
+
+        function initGui(obj)
+            obj.guihandles.preview_button.Callback = @(~,~) obj.runPreview();
+            obj.guihandles.detect_button.Callback  = @(~,~) obj.runDetect();
+        end
+
+        function runPreview(obj)
+            params = obj.getParams();
+            if isempty(params), return; end
+            obj.doDetect(params, true);
+        end
+
+        function runDetect(obj)
+            params = obj.getParams();
+            if isempty(params), return; end
+            obj.doDetect(params, false);
+        end
+
+        function pard=guidef(obj)
+            pard=guidef_SiteAutoDetect(obj);
+        end
+    end
+
+    methods(Access=private)
+        function params = getParams(obj)
+            params = [];
+            try
+                params.threshold    = str2double(obj.guihandles.threshold_edit.String);
+                params.min_dist_nm  = str2double(obj.guihandles.min_dist_edit.String);
+                params.blur_sigma   = str2double(obj.guihandles.blur_sigma_edit.String);
+                params.min_locs     = str2double(obj.guihandles.min_locs_edit.String);
+                params.locs_bins    = str2double(obj.guihandles.locs_bins_edit.String);
+                params.clear_sites  = obj.guihandles.clear_sites.Value;
+                strs = obj.guihandles.filter_mode.String;
+                params.filter_mode  = strs{obj.guihandles.filter_mode.Value}; % 'Exclude' or 'Mark'
+            catch
+                warndlg('Could not read GUI parameters.'); return;
+            end
+            if any(isnan([params.threshold params.min_dist_nm params.blur_sigma params.min_locs]))
+                warndlg('Invalid parameter values.'); params=[]; return;
+            end
+            % Read SE parameters
+            try
+                params.cell_fov  = obj.getPar('se_cellfov');
+                params.site_roi  = obj.getPar('se_siteroi');
+            catch
+                params.cell_fov  = 5000;
+                params.site_roi  = 300;
+            end
+        end
+
+        function doDetect(obj, params, preview_only)
+            threshold   = params.threshold;
+            min_dist_nm = params.min_dist_nm;
+            blur_sigma  = params.blur_sigma;
+            min_locs    = params.min_locs;
+            site_roi    = params.site_roi;
+            cell_fov    = params.cell_fov;
+            pixel_nm    = 10;
+
+            % ── 1. Get all localizations ──────────────────────────────────
+            try
+                locs = obj.locData.getloc({'xnm','ynm'}, 'removeFilter', 'filenumber');
+            catch
+                locs = obj.locData.getloc({'xnm','ynm'});
+            end
+            xnm = double(locs.xnm(:));
+            ynm = double(locs.ynm(:));
+            if isempty(xnm)
+                warndlg('No localizations loaded.'); return;
+            end
+
+            % ── 2. Build density map ──────────────────────────────────────
+            x_min = min(xnm);  y_min = min(ynm);
+            W = ceil((max(xnm) - x_min) / pixel_nm) + 1;
+            H = ceil((max(ynm) - y_min) / pixel_nm) + 1;
+            xi = min(W, max(1, round((xnm - x_min) / pixel_nm) + 1));
+            yi = min(H, max(1, round((ynm - y_min) / pixel_nm) + 1));
+            img = accumarray([yi, xi], 1, [H W]);
+
+            % ── 3. Blur ───────────────────────────────────────────────────
+            sigma_px = blur_sigma / pixel_nm;
+            if exist('imgaussfilt','file') || exist('imgaussfilt','builtin')
+                img_blur = imgaussfilt(double(img), sigma_px);
+            else
+                h = fspecial('gaussian', 2*ceil(3*sigma_px)+1, sigma_px);
+                img_blur = imfilter(double(img), h, 'replicate');
+            end
+
+            % 99th-percentile normalisation for better contrast in preview
+            p99 = prctile(img_blur(img_blur>0), 99);
+            if p99 == 0, p99 = max(img_blur(:)) + eps; end
+            img_norm = img_blur / p99;
+            img_norm(img_norm > 1) = 1;
+
+            % ── 4. Find local maxima ──────────────────────────────────────
+            thresh_abs = threshold;   % threshold is already on 0-1 scale of img_norm
+            if exist('imregionalmax','file') || exist('imregionalmax','builtin')
+                bw = imregionalmax(img_norm) & (img_norm > thresh_abs);
+            else
+                se_dil = strel('disk', max(1, round(sigma_px)));
+                bw = (imdilate(img_norm, se_dil) == img_norm) & (img_norm > thresh_abs);
+            end
+            [rows, cols] = find(bw);
+            if isempty(rows)
+                msgbox('No sites detected. Try lowering the threshold.'); return;
+            end
+
+            % ── 5. To nm, sort, min-distance suppression ─────────────────
+            x_peaks = (cols - 1) * pixel_nm + x_min;
+            y_peaks = (rows - 1) * pixel_nm + y_min;
+            intensities = img_norm(sub2ind(size(img_norm), rows, cols));
+            [~, order]  = sort(intensities, 'descend');
+            x_peaks = x_peaks(order);
+            y_peaks = y_peaks(order);
+
+            N = length(x_peaks);
+            kept = true(N, 1);
+            if N > 1000 && (exist('knnsearch','file') || exist('knnsearch','builtin'))
+                coords = [x_peaks, y_peaks];
+                for k = 1:N
+                    if ~kept(k), continue; end
+                    idx = knnsearch(coords, coords(k,:), 'K', min(N,200));
+                    idx = idx(idx > k);
+                    d   = sqrt(sum((coords(idx,:) - coords(k,:)).^2, 2));
+                    kept(idx(d < min_dist_nm)) = false;
+                end
+            else
+                for k = 1:N
+                    if ~kept(k), continue; end
+                    dists = sqrt((x_peaks - x_peaks(k)).^2 + (y_peaks - y_peaks(k)).^2);
+                    dists(k) = Inf;
+                    rm = find(kept & dists < min_dist_nm & (1:N)' > k);
+                    kept(rm) = false;
+                end
+            end
+            x_peaks = x_peaks(kept);
+            y_peaks = y_peaks(kept);
+
+            % ── 6. Centroid refinement (uses se_siteroi) ──────────────────
+            filenumber = [];
+            if ~isempty(obj.SE.files) && obj.SE.numberOfFiles > 0
+                filenumber = obj.SE.files(1).ID;
+            end
+            for k = 1:length(x_peaks)
+                try
+                    if ~isempty(filenumber)
+                        rl = obj.locData.getloc({'xnm','ynm'}, ...
+                            'position', [x_peaks(k), y_peaks(k), site_roi], ...
+                            'filenumber', filenumber);
+                    else
+                        rl = obj.locData.getloc({'xnm','ynm'}, ...
+                            'position', [x_peaks(k), y_peaks(k), site_roi]);
+                    end
+                    if ~isempty(rl.xnm) && length(rl.xnm) >= 3
+                        x_peaks(k) = mean(double(rl.xnm));
+                        y_peaks(k) = mean(double(rl.ynm));
+                    end
+                catch
+                end
+            end
+
+            % ── 7. Count locs per site & apply min_locs filter ───────────
+            n_sites = length(x_peaks);
+            locs_count = zeros(n_sites, 1);
+            for k = 1:n_sites
+                try
+                    if ~isempty(filenumber)
+                        rl = obj.locData.getloc({'xnm'}, ...
+                            'position', [x_peaks(k), y_peaks(k), site_roi], ...
+                            'filenumber', filenumber);
+                    else
+                        rl = obj.locData.getloc({'xnm'}, ...
+                            'position', [x_peaks(k), y_peaks(k), site_roi]);
+                    end
+                    locs_count(k) = length(rl.xnm);
+                catch
+                    locs_count(k) = 0;
+                end
+            end
+
+            passes = locs_count >= min_locs;
+
+            % ── 8. Update GUI label ───────────────────────────────────────
+            n_found = sum(passes);
+            try
+                obj.guihandles.nsites_label.String = sprintf('N sites found: %d  (excl. %d by locs filter)', ...
+                    n_found, sum(~passes));
+            catch
+            end
+
+            % ── 9. Preview ────────────────────────────────────────────────
+            if preview_only
+                cols_k = round((x_peaks - x_min) / pixel_nm) + 1;
+                rows_k = round((y_peaks - y_min) / pixel_nm) + 1;
+
+                figure('Name','SiteAutoDetect Preview','Color','k', ...
+                    'Units','normalized','Position',[0.1 0.1 0.8 0.45]);
+
+                % Left: density map
+                subplot(1,2,1);
+                imagesc(img_norm); colormap(gca, hot); axis equal tight; colorbar;
+                hold on;
+                % Passed sites: cyan circles
+                plot(cols_k(passes),  rows_k(passes),  'co', 'MarkerSize',10,'LineWidth',2);
+                % Filtered sites: yellow x
+                plot(cols_k(~passes), rows_k(~passes), 'yx', 'MarkerSize', 8,'LineWidth',1.5);
+                title(sprintf('threshold=%.3f  |  %d sites  (%d below locs filter)', ...
+                    threshold, n_found, sum(~passes)), 'Color','w');
+                legend({'pass','locs<min'},'TextColor','w','Color','none','EdgeColor','none');
+
+                % Right: histogram of locs per site
+                subplot(1,2,2);
+                bins = max(1, round(params.locs_bins));
+                if ~isempty(locs_count)
+                    histogram(locs_count, bins, 'FaceColor',[0.2 0.6 1], 'EdgeColor','none');
+                end
+                hold on;
+                yl = ylim;
+                plot([min_locs min_locs], yl, 'r--', 'LineWidth', 2);
+                xlabel('Locs per site'); ylabel('N ROIs');
+                title('Locs distribution', 'Color','w');
+                set(gca,'Color','k','XColor','w','YColor','w');
+                legend({sprintf('histogram'), sprintf('min\\_locs=%.0f',min_locs)}, ...
+                    'TextColor','w','Color','none','EdgeColor','none');
+
+                set(gcf,'Color','k');
+                fprintf('[SiteAutoDetect] Preview: %d/%d sites pass, locs filter=%d\n', ...
+                    n_found, length(x_peaks), min_locs);
+                return;
+            end
+
+            % ── 10. Add to SE ─────────────────────────────────────────────
+            se = obj.SE;
+            if isempty(se.files) || se.numberOfFiles == 0
+                warndlg('No files in Site Explorer. Load data first.'); return;
+            end
+            filenumber = se.files(1).ID;
+
+            % Clear existing sites if requested
+            if params.clear_sites && se.numberOfSites > 0
+                ids = [se.sites(:).ID];
+                for k = 1:length(ids)
+                    try se.removeSite(ids(k)); catch, end
+                end
+                if se.numberOfCells > 0
+                    cids = [se.cells(:).ID];
+                    for k = 1:length(cids)
+                        try se.removeCell(cids(k)); catch, end
+                    end
+                end
+            end
+
+            % Build cell grid: one cell per grid tile that contains ≥1 site
+            half = cell_fov / 2;
+            x_fov_min = min(x_peaks) - half;
+            y_fov_min = min(y_peaks) - half;
+            % Grid indices for each site
+            gx = floor((x_peaks - x_fov_min) / cell_fov);  % 0-based
+            gy = floor((y_peaks - y_fov_min) / cell_fov);
+            grid_ids = gx * 1e6 + gy;  % unique key per tile
+
+            [unique_tiles, ~, tile_idx] = unique(grid_ids);
+            cellID_map = containers.Map('KeyType','double','ValueType','int32');
+
+            for t = 1:length(unique_tiles)
+                tile = unique_tiles(t);
+                gxi = mod(tile, 1e6);   % recover gx
+                gyi = tile - gxi * 1e6; % recover gy  (note: tile=gx*1e6+gy)
+                cx = x_fov_min + (gxi + 0.5) * cell_fov;
+                cy = y_fov_min + (gyi + 0.5) * cell_fov;
+                newcell = interfaces.SEsites;
+                newcell.pos = [cx, cy, 0];
+                newcell.ID  = 0;
+                newcell.info.filenumber = filenumber;
+                cid = se.addCell(newcell);
+                cellID_map(double(tile)) = int32(cid);
+            end
+
+            % Add sites
+            n_added = 0;
+            for k = 1:length(x_peaks)
+                use_flag = passes(k);
+                if strcmp(params.filter_mode, 'Exclude') && ~use_flag
+                    continue;
+                end
+                site = interfaces.SEsites;
+                site.pos  = [x_peaks(k), y_peaks(k), 0];
+                site.ID   = 0;
+                site.info.filenumber = filenumber;
+                site.info.cell       = double(cellID_map(grid_ids(k)));
+                site.annotation.use  = use_flag;
+                se.addSite(site);
+                n_added = n_added + 1;
+            end
+
+            % Refresh SE display
+            try
+                se.processors.preview.updateCelllist;
+                se.processors.preview.updateSitelist;
+            catch
+            end
+
+            fprintf('[SiteAutoDetect] Added %d sites to SE (%d marked Use=false by locs filter)\n', ...
+                n_added, sum(~passes & strcmp(params.filter_mode,'Mark')));
+        end
+    end
+end
+
+
+function pard = guidef_SiteAutoDetect(obj) %#ok<INUSD>
+
+% ── Row 1: Threshold ─────────────────────────────────────────────────────
+pard.t_thresh.object = struct('String','Threshold (0–1)','Style','text');
+pard.t_thresh.position = [1,1];
+pard.t_thresh.Width = 1.2;
+
+pard.threshold_edit.object = struct('String','0.02','Style','edit');
+pard.threshold_edit.position = [1,2.3];
+pard.threshold_edit.Width = 0.6;
+
+pard.t_thresh_hint.object = struct('String', ...
+    'Fraction of 99th-percentile map value. Lower = more (faint) sites.', ...
+    'Style','text');
+pard.t_thresh_hint.position = [2,1];
+pard.t_thresh_hint.Width = 3;
+
+% ── Row 3: Min site distance ──────────────────────────────────────────────
+pard.t_dist.object = struct('String','Min site distance (nm)','Style','text');
+pard.t_dist.position = [3,1];
+pard.t_dist.Width = 1.2;
+
+pard.min_dist_edit.object = struct('String','150','Style','edit');
+pard.min_dist_edit.position = [3,2.3];
+pard.min_dist_edit.Width = 0.6;
+
+% ── Row 4: Blur sigma ────────────────────────────────────────────────────
+pard.t_blur.object = struct('String','Blur sigma (nm)','Style','text');
+pard.t_blur.position = [4,1];
+pard.t_blur.Width = 1.2;
+
+pard.blur_sigma_edit.object = struct('String','40','Style','edit');
+pard.blur_sigma_edit.position = [4,2.3];
+pard.blur_sigma_edit.Width = 0.6;
+
+% ── Row 5: Min locs per site ─────────────────────────────────────────────
+pard.t_minlocs.object = struct('String','Min locs per site','Style','text');
+pard.t_minlocs.position = [5,1];
+pard.t_minlocs.Width = 1.2;
+
+pard.min_locs_edit.object = struct('String','10','Style','edit');
+pard.min_locs_edit.position = [5,2.3];
+pard.min_locs_edit.Width = 0.6;
+
+% ── Row 6: Filter mode + histogram bins ──────────────────────────────────
+pard.t_filtermode.object = struct('String','Locs filter action','Style','text');
+pard.t_filtermode.position = [6,1];
+pard.t_filtermode.Width = 1.2;
+
+pard.filter_mode.object = struct('String',{{'Exclude','Mark (Use=false)'}},'Style','popupmenu');
+pard.filter_mode.position = [6,2.3];
+pard.filter_mode.Width = 1.2;
+
+pard.t_bins.object = struct('String','Histogram bins','Style','text');
+pard.t_bins.position = [7,1];
+pard.t_bins.Width = 1.2;
+
+pard.locs_bins_edit.object = struct('String','30','Style','edit');
+pard.locs_bins_edit.position = [7,2.3];
+pard.locs_bins_edit.Width = 0.6;
+
+% ── Row 8: Clear checkbox ────────────────────────────────────────────────
+pard.clear_sites.object = struct('String','Clear existing sites first','Style','checkbox','Value',0);
+pard.clear_sites.position = [8,1];
+pard.clear_sites.Width = 2;
+
+% ── Row 9: Buttons ───────────────────────────────────────────────────────
+pard.preview_button.object = struct('String','Preview','Style','pushbutton');
+pard.preview_button.position = [9,1];
+pard.preview_button.Width = 1;
+
+pard.detect_button.object = struct('String','Detect Sites','Style','pushbutton');
+pard.detect_button.position = [9,2];
+pard.detect_button.Width = 1;
+
+% ── Row 10: Status label ─────────────────────────────────────────────────
+pard.nsites_label.object = struct('String','N sites found: ---','Style','text');
+pard.nsites_label.position = [10,1];
+pard.nsites_label.Width = 3;
+
+pard.plugininfo.name        = 'Auto-detect CCP Sites';
+pard.plugininfo.description = ['Detects CCP sites from SMLM localizations via density map + local maxima. ' ...
+    'Threshold is a fraction of the 99th-percentile map intensity. ' ...
+    'Works for both 2D and 3D data.'];
+pard.plugininfo.type        = 'ProcessorPlugin';
+end

--- a/plugins/+Analyze/+other/SiteAutoDetect_README.md
+++ b/plugins/+Analyze/+other/SiteAutoDetect_README.md
@@ -77,23 +77,22 @@ Use the locs histogram (Preview) to decide where to set `min_locs` — look for 
 
 ## Installation
 
-1. Download `SiteAutoDetect.m` from the link above and copy it to `<SMAP_root>/plugins/+Analyze/+other/`
-2. Open `<SMAP_root>/plugins/plugin.m` and add these two entries:
+This plugin has been submitted to the official SMAP repository as **PR #34**:
+**https://github.com/jries/SMAP/pull/34**
 
-   **In the `switch` block** (after the `makeMovieTiff` case):
-   ```matlab
-   case 'Analyze.other.SiteAutoDetect'
-      module=Analyze.other.SiteAutoDetect(varargin{:});
-   ```
-   **In the `out` struct** (after the `VersatileRenderer` line):
-   ```matlab
-   out.Analyze.other.SiteAutoDetect={'Analyze','other','SiteAutoDetect','Auto-detect CCP Sites','ProcessorPlugin'};
-   ```
-3. Run `clear classes` in MATLAB
-4. Plugin appears under **Analyze → other → Auto-detect CCP Sites**
+Once merged, just pull the latest SMAP and the plugin appears automatically — no manual steps needed:
 
-> If you want this included in the official SMAP distribution so everyone gets it on `git pull`,
-> open a pull request from `AndreuBoixPages/SMAP:ccp-autodetect` → `jries/SMAP:master`.
+```bash
+cd <your SMAP folder>
+git pull
+```
+
+Then in MATLAB: `clear classes` (or restart MATLAB), and the plugin will appear under **Analyze → other → Auto-detect CCP Sites**.
+
+> **Before the PR is merged:** download `SiteAutoDetect.m` from
+> `https://github.com/AndreuBoixPages/SMAP/tree/ccp-autodetect/plugins/%2BAnalyze/%2Bother`
+> and copy it manually to `<SMAP_root>/plugins/+Analyze/+other/`. No changes to `plugin.m` needed —
+> SMAP auto-discovers plugins at startup.
 
 ## After detection — verifying it worked
 

--- a/plugins/+Analyze/+other/SiteAutoDetect_README.md
+++ b/plugins/+Analyze/+other/SiteAutoDetect_README.md
@@ -1,0 +1,111 @@
+# SiteAutoDetect — SMAP Plugin for Automatic CCP Site Detection
+
+## What it does
+
+`SiteAutoDetect.m` is a SMAP plugin that automatically detects clathrin-coated pit (CCP) sites from SMLM localizations and adds them directly to the SMAP Site Explorer (SE). No manual clicking required.
+
+## Algorithm
+
+```
+All localizations (xnm, ynm)
+        ↓
+Render 2D density map  (10 nm/pixel, accumarray)
+        ↓
+Gaussian blur  (blur_sigma_nm)
+        ↓
+Normalise to 99th percentile  (better contrast than max-normalisation)
+        ↓
+imregionalmax()  →  keep only local maxima above threshold
+        ↓
+Greedy min-distance suppression  (min_dist_nm)
+        ↓
+Centroid refinement  (recenter each peak on the centroid of locs within se_siteroi)
+        ↓
+Count locs per site  (within se_siteroi radius)
+        ↓
+Apply min-locs filter  (exclude OR mark with Use=false)
+        ↓
+Assign sites to a grid of cells  (grid size = se_cellfov from SE Settings)
+        ↓
+Add sites + cells to SE
+```
+
+Works for both **2D and 3D** data (only xnm/ynm are used for detection; z is set to 0).
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| Threshold | 0.02 | Fraction of the 99th-percentile density map value. Lower = more (fainter) sites detected. |
+| Min site distance (nm) | 150 | Minimum distance between two detected peaks. Prevents double-detection of the same CCP. |
+| Blur sigma (nm) | 40 | Gaussian smoothing of the density map before peak finding. Should roughly match the apparent size of one CCP spot. |
+| Min locs per site | 10 | Sites with fewer localizations within `se_siteroi` are filtered. |
+| Locs filter action | Exclude | What to do with sites below min locs: **Exclude** = don't add to SE; **Mark (Use=false)** = add with `-` in the site list. |
+| Histogram bins | 30 | Number of bins for the locs-per-site histogram shown in Preview. |
+| Clear existing sites | unchecked | If checked, removes all existing sites (and cells) from the SE before adding new ones. |
+
+`se_cellfov` and `se_siteroi` are read automatically from the SE Settings panel (not shown in the plugin GUI).
+
+## Buttons
+
+- **Preview** — runs the full pipeline and shows a figure with:
+  - Left panel: density map with detected sites overlaid (cyan = pass, yellow × = below locs filter)
+  - Right panel: histogram of locs per site with a red dashed line at `min_locs`
+  - Does **not** modify the SE.
+- **Detect Sites** — same pipeline, writes results to the SE.
+- **Run** (SMAP's built-in button) — same as Detect Sites.
+
+## Tuning tips
+
+Start with Preview. Typical good starting values for CCP data:
+- `blur_sigma = 40 nm` (keep low — CCPs are small and dense)
+- `threshold = 0.02–0.05`
+- `min_dist = 150 nm` (CCPs are ~150–200 nm apart minimum)
+- `min_locs = 10–30` depending on labelling efficiency
+
+Use the locs histogram (Preview) to decide where to set `min_locs` — look for the natural separation between real sites and noise peaks.
+
+## Files
+
+| File | Location | Purpose |
+|---|---|---|
+| `SiteAutoDetect.m` | `plugins/+Analyze/+other/` on the `ccp-autodetect` branch | Plugin class |
+| `SiteAutoDetect_README.md` | same folder | This document (install + usage instructions) |
+
+`SiteAutoDetect.m` is available at:
+**https://github.com/AndreuBoixPages/SMAP/tree/ccp-autodetect/plugins/%2BAnalyze/%2Bother**
+
+## Installation
+
+1. Download `SiteAutoDetect.m` from the link above and copy it to `<SMAP_root>/plugins/+Analyze/+other/`
+2. Open `<SMAP_root>/plugins/plugin.m` and add these two entries:
+
+   **In the `switch` block** (after the `makeMovieTiff` case):
+   ```matlab
+   case 'Analyze.other.SiteAutoDetect'
+      module=Analyze.other.SiteAutoDetect(varargin{:});
+   ```
+   **In the `out` struct** (after the `VersatileRenderer` line):
+   ```matlab
+   out.Analyze.other.SiteAutoDetect={'Analyze','other','SiteAutoDetect','Auto-detect CCP Sites','ProcessorPlugin'};
+   ```
+3. Run `clear classes` in MATLAB
+4. Plugin appears under **Analyze → other → Auto-detect CCP Sites**
+
+> If you want this included in the official SMAP distribution so everyone gets it on `git pull`,
+> open a pull request from `AndreuBoixPages/SMAP:ccp-autodetect` → `jries/SMAP:master`.
+
+## After detection — verifying it worked
+
+```matlab
+se = g.locData.SE;
+fprintf('Sites detected: %d\n', length(se.sites));
+fprintf('First site at (%.0f, %.0f) nm\n', se.sites(1).pos(1), se.sites(1).pos(2));
+```
+
+## Known limitations / future work
+
+- Cell grid uses a fixed tile size (`se_cellfov`). For very non-uniform datasets, cells at the edge of the FOV may be only partially filled.
+- Centroid refinement uses a circular ROI of radius `se_siteroi`. If two CCPs are closer than this, the centroid may be pulled between them. Consider reducing `se_siteroi` in the SE Settings if CCPs are very dense.
+- Currently uses only 2D positions for detection. A future version could incorporate z-position to detect 3D clusters in thick samples.
+- The min-locs filter counts all localizations within the ROI regardless of z. For 3D data, adding a z-range filter would improve specificity.

--- a/plugins/+ROIManager/+Analyze/AverageSitesByDistance.m
+++ b/plugins/+ROIManager/+Analyze/AverageSitesByDistance.m
@@ -1,0 +1,569 @@
+classdef AverageSitesByDistance < interfaces.DialogProcessor & interfaces.SEProcessor
+% Average sites grouped by distance bins (nm).
+% Bin edges can be a single number (uniform bins of that width, starting
+% from 0) or a comma-separated list of thresholds (custom edges, with
+% -inf and +inf added automatically at both ends).
+% Examples:
+%   "20"        -> bins [0,20), [20,40), [40,60), ...
+%   "10,20,50"  -> bins (-inf,10), [10,20), [20,50), [50,+inf)
+    methods
+        function obj = AverageSitesByDistance(varargin)
+            obj@interfaces.DialogProcessor(varargin{:});
+            obj.inputParameters = {'se_viewer', 'se_siteroi', 'se_sitefov'};
+            obj.showresults = true;
+        end
+
+        function out = run(obj, p)
+            out = [];
+            sites = obj.locData.SE.sites;
+            if isempty(sites)
+                obj.status('No sites loaded.'); return
+            end
+            roisize = ones(2,1) * obj.P.par.se_siteroi.content;
+
+            % --- get per-site distance values ---
+            distField = strtrim(p.distField);
+            if isempty(distField)
+                errordlg('Please specify a distance field.', 'AverageSitesByDistance');
+                return
+            end
+            distances = getSiteDistances(sites, distField);
+            validMask = ~isnan(distances);
+
+            % apply distance range filter
+            minD = str2double(num2str(p.minDist));
+            maxD = str2double(num2str(p.maxDist));
+            if isnan(minD), minD = 0;   end
+            if isnan(maxD), maxD = Inf; end
+            validMask = validMask & distances >= minD & distances <= maxD;
+
+            if sum(validMask) == 0
+                errordlg(['No valid values found in field: ' distField], 'AverageSitesByDistance');
+                return
+            end
+
+            % --- parse bin edges ---
+            binEdges = parseBinSpec(p.binSpec, distances(validMask));
+            if isempty(binEdges) || length(binEdges) < 2
+                errordlg('Could not parse bin specification.', 'AverageSitesByDistance');
+                return
+            end
+            numBins = length(binEdges) - 1;
+
+            % --- pre-count sites per bin (for histogram) ---
+            binCounts = zeros(1, numBins);
+            binLabels = cell(1, numBins);
+            for l = 1:numBins
+                lo = binEdges(l); hi = binEdges(l+1);
+                if l < numBins
+                    binCounts(l) = sum(distances >= lo & distances < hi);
+                else
+                    binCounts(l) = sum(distances >= lo & distances <= hi);
+                end
+                binLabels{l} = sprintf('[%s,%s)', fmt(lo), fmt(hi));
+                obj.status(sprintf('Bin %d: [%s, %s) nm  -> %d sites', ...
+                    l, fmt(lo), fmt(hi), binCounts(l)));
+                drawnow
+            end
+
+            % --- set up averaging machinery (mirrors AverageSites_window) ---
+            fdcal = figure(233);
+            dcal = plugin('ROIManager', 'Evaluate', 'generalStatistics', fdcal, obj.P);
+            dcal.attachLocData(obj.SE.locData);
+            dcal.makeGui;
+
+            xfirst = roisize(1);
+            yfirst = roisize(2);
+            x0 = 0; y0 = 0;
+            locc = [];
+            newfile = obj.locData.files.filenumberEnd;
+            binLocs = {};   % per-bin: struct with xnm1,ynm1,xnm2,ynm2,label,nSites
+
+            if p.inOneFile
+                sitePerRow = max(1, ceil(numBins / max(1, p.rowSites)));
+                flagPlotCol = 1;
+                flagPlotRow = 1;
+                newfile = obj.locData.files.filenumberEnd + 1;
+                oneFilename = ['distBins_F' num2str(newfile)];
+                if p.addfile
+                    obj.locData.addfile(oneFilename);
+                    initGuiAfterLoad(obj);
+                    obj.SE.processors.preview.updateFilelist;
+                end
+            end
+
+            for l = 1:numBins
+                lo = binEdges(l); hi = binEdges(l+1);
+
+                if l < numBins
+                    inBin = distances >= lo & distances < hi;
+                else
+                    inBin = distances >= lo & distances <= hi;
+                end
+                binIdx = find(inBin);
+
+                if isempty(binIdx)
+                    obj.status(sprintf('Bin %d [%s,%s): 0 sites, skipping.', l, fmt(lo), fmt(hi)));
+                    drawnow; continue
+                end
+
+                % --- apply per-bin site cap (for fast preview) ---
+                maxS = round(p.maxSites);
+                if maxS > 0 && length(binIdx) > maxS
+                    binIdx = binIdx(randperm(length(binIdx), maxS));
+                end
+
+                if ~p.inOneFile
+                    oneFilename = [fmt(lo) 'to' fmt(hi) 'nm'];
+                    newfile = obj.locData.files.filenumberEnd + 1;
+                    if p.addfile
+                        obj.locData.addfile(oneFilename);
+                        initGuiAfterLoad(obj);
+                        obj.SE.processors.preview.updateFilelist;
+                    end
+                end
+
+                if p.inOneFile
+                    x0 = xfirst + (flagPlotCol-1) * roisize(1);
+                    y0 = yfirst + (flagPlotRow-1) * roisize(2);
+                    flagPlotCol = flagPlotCol + 1;
+                    if flagPlotCol > sitePerRow
+                        flagPlotRow = flagPlotRow + 1;
+                        flagPlotCol = 1;
+                    end
+                end
+
+                allIndLoc  = [];
+                xnmrotAll  = [];
+                ynmrotAll  = [];
+                classAll   = [];
+                ticc = tic;
+
+                for ki = 1:length(binIdx)
+                    k = binIdx(ki);
+                    if p.sortselection.Value == 1 || sites(k).annotation.use
+                        dcal.site = sites(k);
+                        dcal.site.image = obj.locData.SE.plotsite(sites(k));
+                        [locsSite, indloc] = dcal.getLocs({'xnmrot','ynmrot'}, ...
+                            'size', roisize', 'grouping', 'ungrouped');
+                        indloc = find(indloc);
+                        if ~isempty(indloc)
+                            allIndLoc(end+1:end+length(indloc), :)  = indloc;
+                            xnmrotAll(end+1:end+length(indloc), :)  = locsSite.xnmrot;
+                            ynmrotAll(end+1:end+length(indloc), :)  = locsSite.ynmrot;
+                            classAll(end+1:end+length(indloc), :)   = sites(k).ID;
+                        end
+                    end
+                    if toc(ticc) > 1
+                        ticc = tic;
+                        obj.status(sprintf('Bin %d/%d  site %d/%d', l, numBins, ki, length(binIdx)));
+                        drawnow
+                    end
+                end
+
+                if isempty(allIndLoc), continue, end
+
+                locnew = obj.locData.loc;
+                subsel = @(x) x(allIndLoc, :);
+                locnew = structfun(subsel, locnew, 'UniformOutput', false);
+                locnew.xnm       = xnmrotAll;
+                locnew.ynm       = ynmrotAll;
+                locnew.class     = classAll;
+                locnew.origin    = allIndLoc;
+                locnew.filenumber = repelem(newfile, length(allIndLoc))';
+
+                locc = obj.locData.copy;
+                locc.loc = locnew;
+                locc.regroup;
+                locc.filter;
+
+                % --- store averaged locs for this bin (for subplot figure) ---
+                layers_on = find(obj.getPar('sr_layerson'));
+                lc1 = locc.getloc({'xnm','ynm'}, 'layer', 1, 'position', 'all', 'filenumber', newfile);
+                lc2.xnm = []; lc2.ynm = [];
+                if any(layers_on == 2)
+                    lc2 = locc.getloc({'xnm','ynm'}, 'layer', 2, 'position', 'all', 'filenumber', newfile);
+                end
+                binLocs{end+1} = struct( ...
+                    'xnm1', lc1.xnm, 'ynm1', lc1.ynm, ...
+                    'xnm2', lc2.xnm, 'ynm2', lc2.ynm, ...
+                    'label', binLabels{l}, 'nSites', length(binIdx));
+
+                if p.addfile
+                    locnew.xnm = locnew.xnm + x0;
+                    locnew.ynm = locnew.ynm + y0;
+                    fn = fieldnames(locnew);
+                    for kf = 1:length(fn)
+                        obj.locData.addloc(fn{kf}, locnew.(fn{kf}));
+                    end
+                    obj.locData.regroup;
+                    obj.locData.filter;
+                end
+            end
+
+            if isempty(locc)
+                obj.status('No bins contained any sites.'); return
+            end
+
+            % --- Figure 1: histogram of sites per bin ---
+            fhist = figure(901);
+            clf(fhist);
+            ax1 = axes(fhist);
+            nonEmptyMask = binCounts > 0;
+            bar(ax1, find(nonEmptyMask), binCounts(nonEmptyMask), 'FaceColor', [0.25 0.55 0.85]);
+            set(ax1, 'XTick', 1:numBins, 'XTickLabel', binLabels, ...
+                'XTickLabelRotation', 45);
+            xlabel(ax1, 'Distance bin (nm)');
+            ylabel(ax1, 'Number of sites');
+            title(ax1, 'Sites per distance bin');
+            grid(ax1, 'on');
+
+            % --- Figure 2: averaged localization scatter, one subplot per bin ---
+            if ~isempty(binLocs)
+                nPlots  = length(binLocs);
+                nCols   = min(nPlots, 5);
+                nRows   = ceil(nPlots / nCols);
+                hasTwo  = any(cellfun(@(b) ~isempty(b.xnm2), binLocs));
+
+                favg = figure(902);
+                clf(favg);
+                set(favg, 'Name', 'Averaged sites per distance bin', 'NumberTitle', 'off');
+
+                % global axis limits so all subplots are on the same scale
+                allX = cellfun(@(b) [b.xnm1(:); b.xnm2(:)], binLocs, 'UniformOutput', false);
+                allY = cellfun(@(b) [b.ynm1(:); b.ynm2(:)], binLocs, 'UniformOutput', false);
+                allX = cat(1, allX{:});  allY = cat(1, allY{:});
+                xLim = [min(allX) max(allX)];
+                yLim = [min(allY) max(allY)];
+
+                for bi = 1:nPlots
+                    b  = binLocs{bi};
+                    ax = subplot(nRows, nCols, bi, 'Parent', favg);
+                    hold(ax, 'on');
+                    plot(ax, b.xnm1, b.ynm1, '.', 'MarkerSize', 1, 'Color', [0.20 0.55 0.85]);
+                    if hasTwo && ~isempty(b.xnm2)
+                        plot(ax, b.xnm2, b.ynm2, '.', 'MarkerSize', 1, 'Color', [0.85 0.33 0.10]);
+                    end
+                    hold(ax, 'off');
+                    axis(ax, 'equal');
+                    xlim(ax, xLim);  ylim(ax, yLim);
+                    box(ax, 'off');
+                    set(ax, 'XTick', [], 'YTick', []);
+                    title(ax, sprintf('%s nm  (n=%d)', b.label, b.nSites), ...
+                        'FontSize', 7, 'Interpreter', 'none');
+                end
+
+                if hasTwo
+                    sgtitle(favg, 'Averaged sites per distance bin  ●Ch1 (ring)  ●Ch2 (cap)');
+                else
+                    sgtitle(favg, 'Averaged sites per distance bin');
+                end
+            end
+        end
+
+        function pard = guidef(obj)
+            pard = guidef(obj);
+        end
+    end
+end
+
+% -------------------------------------------------------------------------
+% Button callbacks
+% -------------------------------------------------------------------------
+
+function selectField_callback(~, ~, obj)
+% Browse site fields to fill the distance field edit box.
+% If the selected field is a numeric array, shows an extra dialog
+% listing each element together with its name (if a parallel .name
+% field exists – as in allParsArg.value / allParsArg.name).
+site = obj.SE.currentsite;
+if isempty(site), return, end
+
+str = browsefields(site, '');
+if isempty(str) || strcmp(str, 'abortbutton'), return, end
+
+% If the returned field is a numeric array we need an index
+try
+    val = eval(['site.' str]);
+    if isnumeric(val) && numel(val) > 1
+        % Try to find a companion .name field (e.g. allParsArg.name)
+        parts = strsplit(str, '.');
+        nameFieldParts      = parts;
+        nameFieldParts{end} = 'name';
+        nameFieldStr        = strjoin(nameFieldParts, '.');
+        typeFieldParts      = parts;
+        typeFieldParts{end} = 'type';
+        typeFieldStr        = strjoin(typeFieldParts, '.');
+        try
+            nameVals = eval(['site.' nameFieldStr]);
+            try, typeVals = eval(['site.' typeFieldStr]); catch, typeVals = {}; end
+            listItems = cell(numel(val), 1);
+            for k = 1:numel(val)
+                nm = nameVals{k};
+                if ~isempty(typeVals)
+                    nm = [typeVals{k} '.' nm]; %#ok<AGROW>
+                end
+                listItems{k} = sprintf('%d:  %-25s = %.4g', k, nm, val(k));
+            end
+        catch
+            listItems = arrayfun(@(k) sprintf('%d:  %.4g', k, val(k)), ...
+                                 1:numel(val), 'UniformOutput', false)';
+        end
+        idx = listdlg('ListString', listItems, ...
+                      'SelectionMode', 'single', ...
+                      'Name',          'Select distance parameter', ...
+                      'PromptString',  'Pick the parameter that encodes distance:', ...
+                      'ListSize',      [340 300]);
+        if isempty(idx), return, end
+        str = [str '(' num2str(idx) ')'];
+    end
+catch
+    % Cannot evaluate – use the string as-is
+end
+
+obj.guihandles.distField.String = str;
+end
+
+function previewBins_callback(~, ~, obj)
+% Show bin counts without running the full averaging
+sites = obj.locData.SE.sites;
+if isempty(sites), disp('No sites'); return, end
+p = obj.getAllParameters;
+distField = strtrim(p.distField);
+if isempty(distField), disp('No field specified'); return, end
+distances = getSiteDistances(sites, distField);
+validMask = ~isnan(distances);
+if sum(validMask) == 0
+    disp(['No valid values in field: ' distField]); return
+end
+binEdges = parseBinSpec(p.binSpec, distances(validMask));
+if isempty(binEdges) || length(binEdges) < 2
+    disp('Could not parse bin spec'); return
+end
+numBins = length(binEdges) - 1;
+msg = sprintf('Distance field: %s\n\n', distField);
+for l = 1:numBins
+    lo = binEdges(l); hi = binEdges(l+1);
+    if l < numBins
+        n = sum(distances >= lo & distances < hi);
+    else
+        n = sum(distances >= lo & distances <= hi);
+    end
+    msg = [msg sprintf('  Bin %d: [%s, %s) nm  ->  %d sites\n', ...
+        l, fmt(lo), fmt(hi), n)]; %#ok<AGROW>
+end
+msg = [msg sprintf('\nTotal valid sites: %d / %d', sum(validMask), length(sites))];
+msgbox(msg, 'Bin preview', 'help');
+end
+
+% -------------------------------------------------------------------------
+% Local helpers
+% -------------------------------------------------------------------------
+
+function distances = getSiteDistances(sites, distField)
+% Evaluate distField for every site.
+%
+% Two syntaxes are supported:
+%
+%  1. Field path  (default):
+%       evaluation.LocMoFitGUI.allParsArg.value(14)
+%     Evaluated as  s.<distField>  where s = sites(k).
+%
+%  2. Formula  (prefix with @):
+%       @sqrt(v(1)^2 + (v(2)-v(14))^2)
+%     The expression after @ is evaluated with these variables in scope:
+%       s  = sites(k)                           (full site struct)
+%       ap = s.evaluation.LocMoFitGUI.allParsArg  (allParsArg struct, if present)
+%       v  = ap.value                           (parameter value vector)
+%     Use this when the distance must be computed from multiple parameters,
+%     e.g. the Euclidean distance between a ring and a cap model.
+isFormula = ischar(distField) && ~isempty(distField) && distField(1) == '@';
+if isFormula
+    expr = distField(2:end);   % strip the leading '@'
+end
+
+% debug: print what we received
+fprintf('getSiteDistances: ischar=%d  isFormula=%d  distField="%s"\n', ...
+    ischar(distField), isFormula, num2str(distField));
+
+distances = NaN(1, length(sites));
+firstErr = '';
+for k = 1:length(sites)
+    try
+        s = sites(k); %#ok<NASGU>
+        if isFormula
+            % make ap and v available if allParsArg exists
+            try
+                ap = s.evaluation.LocMoFitGUI.allParsArg; %#ok<NASGU>
+                v  = ap.value; %#ok<NASGU>
+            catch
+            end
+            val = eval(expr);
+        else
+            val = eval(['s.' distField]);
+            if isstruct(val)
+                val = val.value;
+            end
+            val = val(1);
+        end
+        distances(k) = val;
+    catch err
+        if isempty(firstErr)
+            firstErr = err.message;
+        end
+    end
+end
+if ~isempty(firstErr)
+    fprintf('getSiteDistances: first error was: %s\n', firstErr);
+end
+end
+
+function edges = parseBinSpec(specStr, validDists)
+% Returns bin edges as a row vector.
+% Single number  -> uniform bins starting from 0.
+% Multiple numbers -> custom edges with -inf and +inf appended.
+%
+% Note: SMAP's getAllParameters() converts single-number edit-box strings
+% to doubles automatically, so specStr may arrive as a numeric scalar.
+if isnumeric(specStr)
+    nums = specStr;
+else
+    specStr = strtrim(specStr);
+    parts = strsplit(specStr, ',');
+    nums = cellfun(@str2double, strtrim(parts));
+    nums = nums(~isnan(nums));
+end
+
+if isempty(nums)
+    edges = [];
+    return
+end
+
+if isscalar(nums)
+    bw = nums;
+    if bw <= 0, edges = []; return, end
+    hi = ceil(max(validDists) / bw) * bw;
+    edges = 0 : bw : hi;
+    if isempty(edges) || edges(end) < max(validDists)
+        edges(end+1) = edges(end) + bw;
+    end
+else
+    % Custom thresholds: always start from 0, end at +inf
+    edges = [0, sort(nums(nums > 0)), inf];
+end
+end
+
+function s = fmt(v)
+% Format a bin edge value for display / filename
+if isinf(v) && v < 0
+    s = '-inf';
+elseif isinf(v)
+    s = 'inf';
+else
+    s = num2str(v);
+end
+end
+
+% -------------------------------------------------------------------------
+% GUI definition
+% -------------------------------------------------------------------------
+
+function pard = guidef(obj)
+
+pard.tDist.object  = struct('String', 'Distance field', 'Style', 'text');
+pard.tDist.position = [1, 1];
+pard.tDist.Width   = 1;
+
+pard.distField.object  = struct('String', '', 'Style', 'edit');
+pard.distField.position = [1, 2];
+pard.distField.Width   = 2;
+pard.distField.TooltipString = [...
+    'Path to a per-site scalar, e.g.  evaluation.LocMoFitGUI.allParsArg.value(14)' char(10) ...
+    'For computed distances prefix with @, e.g.:' char(10) ...
+    '  @sqrt(v(1)^2+(v(2)-v(14))^2)' char(10) ...
+    'Inside @ expressions: s=site, ap=allParsArg, v=allParsArg.value'];
+
+pard.selectField.object = struct('String', 'select', 'Style', 'pushbutton', ...
+    'Callback', {{@selectField_callback, obj}});
+pard.selectField.position = [1, 4];
+pard.selectField.Width = 0.7;
+
+pard.tBin.object  = struct('String', 'Bin width or edges (nm)', 'Style', 'text');
+pard.tBin.position = [2, 1];
+pard.tBin.Width   = 1.5;
+
+pard.binSpec.object  = struct('String', '20', 'Style', 'edit');
+pard.binSpec.position = [2, 2.5];
+pard.binSpec.Width   = 1.5;
+pard.binSpec.TooltipString = ['Single number: uniform bin width starting from 0.  e.g. "20" -> [0,20), [20,40), ...' char(10) ...
+    'Comma-separated: custom edges from 0.  e.g. "10,70,200" -> [0,10), [10,70), [70,200), [200,+inf)'];
+
+pard.previewBins.object = struct('String', 'preview', 'Style', 'pushbutton', ...
+    'Callback', {{@previewBins_callback, obj}});
+pard.previewBins.position = [2, 4];
+pard.previewBins.Width = 0.7;
+
+pard.tSort.object  = struct('String', 'Sites to use', 'Style', 'text');
+pard.tSort.position = [3, 1];
+pard.tSort.Width   = 1;
+
+pard.sortselection.object = struct('String', {{'all', 'use'}}, 'Style', 'popupmenu');
+pard.sortselection.position = [3, 2];
+pard.sortselection.Width   = 1;
+
+pard.tName.object  = struct('String', 'Name', 'Style', 'text');
+pard.tName.position = [4, 1];
+pard.tName.Width   = 1;
+
+pard.name.object  = struct('String', 'average', 'Style', 'edit');
+pard.name.position = [4, 2];
+pard.name.Width   = 1;
+
+pard.addfile.object  = struct('String', 'add averages as new datasets', 'Style', 'checkbox', 'Value', 1);
+pard.addfile.position = [4, 3];
+pard.addfile.Width   = 2;
+
+pard.tRow.object  = struct('String', 'Bins per row', 'Style', 'text');
+pard.tRow.position = [5, 1];
+pard.tRow.Width   = 1;
+
+pard.rowSites.object  = struct('String', '4', 'Style', 'edit');
+pard.rowSites.position = [5, 2];
+pard.rowSites.Width   = 0.5;
+
+pard.inOneFile.object  = struct('String', 'all in one file', 'Style', 'checkbox', 'Value', 1);
+pard.inOneFile.position = [5, 3];
+pard.inOneFile.Width   = 1.5;
+
+pard.tMaxSites.object  = struct('String', 'Max sites/bin (0=all)', 'Style', 'text');
+pard.tMaxSites.position = [6, 1];
+pard.tMaxSites.Width   = 1.5;
+
+pard.maxSites.object  = struct('String', '0', 'Style', 'edit');
+pard.maxSites.position = [6, 2.5];
+pard.maxSites.Width   = 0.5;
+
+pard.tDistRange.object  = struct('String', 'Distance range (nm)', 'Style', 'text');
+pard.tDistRange.position = [7, 1];
+pard.tDistRange.Width   = 1.5;
+
+pard.minDist.object  = struct('String', '0', 'Style', 'edit');
+pard.minDist.position = [7, 2.5];
+pard.minDist.Width   = 0.5;
+pard.minDist.TooltipString = 'Minimum distance (nm). Sites below this are excluded.';
+
+pard.tDistTo.object  = struct('String', 'to', 'Style', 'text');
+pard.tDistTo.position = [7, 3];
+pard.tDistTo.Width   = 0.3;
+
+pard.maxDist.object  = struct('String', 'Inf', 'Style', 'edit');
+pard.maxDist.position = [7, 3.3];
+pard.maxDist.Width   = 0.5;
+pard.maxDist.TooltipString = 'Maximum distance (nm). Sites above this are excluded. Leave as Inf for no upper limit.';
+
+pard.plugininfo.name = 'AverageSitesByDistance';
+pard.plugininfo.type = 'ROI_Analyze';
+pard.plugininfo.description = ...
+    'Average sites grouped by a per-site distance parameter. Bin by uniform width or custom nm thresholds.';
+
+end


### PR DESCRIPTION
Two new plugins for CCP/endocytic site analysis.

**SiteAutoDetect** (Analyze > other): Automatically detects clathrin-coated pit sites from SMLM localizations and adds them to the Site Explorer. Uses density map + Gaussian blur + local maxima + centroid refinement + locs-count filter. No manual clicking required. See SiteAutoDetect_README.md for full documentation.

**AverageSitesByDistance** (ROIManager > Analyze): Distance-binned averaging of sites from the ROI Manager.

Both plugins are auto-discovered by SMAP on startup via makeplugincallfile — no changes to plugin.m needed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>